### PR TITLE
Access tokens are now refreshed and Remember Me tokens implemented

### DIFF
--- a/src/config/keys.js
+++ b/src/config/keys.js
@@ -1,1 +1,3 @@
 export const secretkey = 'mysecretkey';
+export const expTime = 1000 * 60 * 20;
+export const rememberTime = 1000 * 60 * 60 * 24 * 2;

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -56,15 +56,16 @@ function verifyToken(token, res, tokenName = 'token') {
 
         // now send a response
         return res.status(401).json({
+            err: true,
             msg: 'Error, token not valid',
         });
     }
 }
 
 // post route to check validity of tokens, clients will hit this route.
-router.post('/verify', (req, res) => {
-    // extract token from cookie
-    const { token, rememberme } = req.cookies;
+router.post('/verify-token', (req, res) => {
+    // extract token from post request body
+    const { token, rememberme } = req.body;
 
     if (!token) {
         if (!rememberme) {
@@ -80,4 +81,4 @@ router.post('/verify', (req, res) => {
 });
 
 export default router;
-export { createJWTCookie };
+export { createJWTCookie, verifyToken };

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,66 +1,7 @@
 import express from 'express';
-import jwt, { verify } from 'jsonwebtoken';
-import { secretkey, expTime, rememberTime } from '../config/keys';
+import { verifyToken } from '../utils/utils';
 
 const router = express.Router();
-
-function createJWTCookie(user, res, tokenName = 'token') {
-    const payload = {
-        user: {
-            id: user._id,
-            email: user.email,
-            firstname: user.firstname,
-            lastname: user.lastname,
-            username: user.username,
-            role: user.role,
-        },
-    };
-    const exp = tokenName === 'rememberme' ? rememberTime : expTime;
-    // create a token
-    const token = jwt.sign(payload, secretkey, {
-        expiresIn: exp, // in ms
-        issuer: 'auth.devclub.in',
-    });
-
-    // set the cookie with token with the same age as that of token
-    res.cookie(tokenName, token, {
-        maxAge: exp, // in ms
-        secure: false, // set to true if your using https
-        httpOnly: true,
-        sameSite: 'lax',
-    });
-}
-
-function verifyToken(token, res, tokenName = 'token') {
-    try {
-        const decoded = verify(token, secretkey);
-        const { user } = decoded;
-
-        // Set a new cookie which will extend the session a further {expTime} amount of time.
-        // So essentially whenever any auth request is made the user session will be extended.
-        if (tokenName === 'rememberme') {
-            // Refresh the remember me cookie
-            createJWTCookie(user, res, tokenName);
-        }
-
-        // Refresh the token cookie
-        createJWTCookie(user, res);
-
-        return res.status(200).json({
-            user,
-        });
-    } catch (err) {
-        // I wasn't able to verify the token as it was invalid
-        // clear the token
-        res.clearCookie(tokenName);
-
-        // now send a response
-        return res.status(401).json({
-            err: true,
-            msg: 'Error, token not valid',
-        });
-    }
-}
 
 // post route to check validity of tokens, clients will hit this route.
 router.post('/verify-token', (req, res) => {
@@ -74,11 +15,12 @@ router.post('/verify-token', (req, res) => {
             });
         }
 
+        // Remember-Me token is present, so use it to authenticate the user
         return verifyToken(rememberme, res, 'rememberme');
     }
 
+    // Access token is present, so verify it.
     return verifyToken(token, res);
 });
 
 export default router;
-export { createJWTCookie, verifyToken };

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,34 +1,83 @@
 import express from 'express';
-import { verify } from 'jsonwebtoken';
-import { secretkey } from '../config/keys';
+import jwt, { verify } from 'jsonwebtoken';
+import { secretkey, expTime, rememberTime } from '../config/keys';
 
 const router = express.Router();
 
-// post route to check validity of tokens, clients will hit this route.
-router.post('/', (req, res) => {
-    // extract token from cookie
-    const token = req.header('auth-token');
+function createJWTCookie(user, res, tokenName = 'token') {
+    const payload = {
+        user: {
+            id: user._id,
+            email: user.email,
+            firstname: user.firstname,
+            lastname: user.lastname,
+            username: user.username,
+            role: user.role,
+        },
+    };
+    const exp = tokenName === 'rememberme' ? rememberTime : expTime;
+    // create a token
+    const token = jwt.sign(payload, secretkey, {
+        expiresIn: exp, // in ms
+        issuer: 'auth.devclub.in',
+    });
 
-    if (!token) {
-        return res.status(401).json({ msg: 'Error, token is not present' });
-    }
+    // set the cookie with token with the same age as that of token
+    res.cookie(tokenName, token, {
+        maxAge: exp, // in ms
+        secure: false, // set to true if your using https
+        httpOnly: true,
+        sameSite: 'lax',
+    });
+}
 
-    // So the token is present, so lets verify it
+function verifyToken(token, res, tokenName = 'token') {
     try {
         const decoded = verify(token, secretkey);
-
         const { user } = decoded;
 
-        return res.status(200).json({ user });
+        // Set a new cookie which will extend the session a further {expTime} amount of time.
+        // So essentially whenever any auth request is made the user session will be extended.
+        if (tokenName === 'rememberme') {
+            // Refresh the remember me cookie
+            createJWTCookie(user, res, tokenName);
+        }
+
+        // Refresh the token cookie
+        createJWTCookie(user, res);
+
+        return res.status(200).json({
+            user,
+        });
     } catch (err) {
         // I wasn't able to verify the token as it was invalid
-        // clear the token, but somehow this doesn't work, so just to
-        // be safe, do the same at client server as well.
-        res.clearCookie('token');
+        // clear the token
+        res.clearCookie(tokenName);
 
         // now send a response
-        return res.status(401).json({ msg: 'Error, token not valid' });
+        return res.status(401).json({
+            msg: 'Error, token not valid',
+        });
     }
+}
+
+// post route to check validity of tokens, clients will hit this route.
+router.post('/verify', (req, res) => {
+    // extract token from cookie
+    const { token, rememberme } = req.cookies;
+
+    if (!token) {
+        if (!rememberme) {
+            return res.status(401).json({
+                msg: 'Error, token is not present',
+            });
+        }
+
+        return verifyToken(rememberme, res, 'rememberme');
+    }
+
+    return verifyToken(token, res);
 });
 
 export default router;
+export { createJWTCookie };

--- a/src/routes/profile.js
+++ b/src/routes/profile.js
@@ -1,6 +1,5 @@
 import express from 'express';
-import { verify } from 'jsonwebtoken';
-import { secretkey } from '../config/keys';
+import { verifyToken } from './auth';
 
 const router = express.Router();
 
@@ -10,33 +9,25 @@ router.get('/settings', (req, res) => {
 
 router.post('/', (req, res) => {
     // extract token from cookie
-    const { token } = req.cookies;
-
-    // no token present
+    const { token, rememberme } = req.cookies;
     if (!token) {
-        return res.status(200).json({ err: true, message: '' });
+        if (!rememberme) {
+            return res.status(401).json({
+                err: true,
+                msg: '',
+            });
+        }
+
+        return verifyToken(rememberme, res, 'rememberme');
     }
 
-    try {
-        const decoded = verify(token, secretkey);
-
-        const { user } = decoded;
-
-        res.send({ user });
-    } catch (err) {
-        // clear the cookie also
-        res.clearCookie('token');
-
-        return res.status(401).json({
-            err: true,
-            message: 'Whoops!! Invalid login attempt...',
-        });
-    }
+    return verifyToken(token, res);
 });
 
 router.post('/logout', (req, res) => {
     try {
         res.clearCookie('token');
+        res.clearCookie('rememberme');
         return res.json({
             err: false,
             message: 'Logged out successfully',

--- a/src/routes/profile.js
+++ b/src/routes/profile.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { verifyToken } from './auth';
+import { verifyToken } from '../utils/utils';
 
 const router = express.Router();
 

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import bcrypt from 'bcryptjs';
-import { createJWTCookie } from './auth';
+import { createJWTCookie } from '../utils/utils';
 import User from '../models/user';
 
 const router = express.Router();

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,8 +1,7 @@
 import express from 'express';
 import bcrypt from 'bcryptjs';
-import jwt from 'jsonwebtoken';
+import { createJWTCookie } from './auth';
 import User from '../models/user';
-import { secretkey } from '../config/keys';
 
 const router = express.Router();
 
@@ -33,7 +32,7 @@ router.get('/register', (req, res) => {
 
 router.post('/login', async (req, res, next) => {
     try {
-        const { email, password, serviceURL } = req.body;
+        const { email, password, serviceURL, rememberme } = req.body;
         // try to find the user in the database
         const user = await User.findOne({ email });
 
@@ -58,29 +57,10 @@ router.post('/login', async (req, res, next) => {
             });
         }
 
-        // Create payload to create a token
-        const payload = {
-            user: {
-                id: user._id,
-                email: user.email,
-                firstname: user.firstname,
-                lastname: user.lastname,
-                username: user.username,
-            },
-        };
-
-        // create a token
-        const token = jwt.sign(payload, secretkey, {
-            expiresIn: 60 * 10 * 1000, // in ms
-        });
-
-        // set the cookie with token with the same age as that of token
-        res.cookie('token', token, {
-            maxAge: 60 * 10 * 1000, // in ms
-            secure: false, // set to true if your using https
-            httpOnly: true,
-            sameSite: 'lax',
-        });
+        createJWTCookie(user, res);
+        if (rememberme === 'true') {
+            createJWTCookie(user, res, 'rememberme');
+        }
 
         if (typeof serviceURL !== 'undefined' && serviceURL) {
             // render homepage to store token and then redirect with serviceURL
@@ -135,29 +115,7 @@ router.post('/register', async (req, res) => {
         // Save the updated the user in database
         await user.save();
 
-        // Create payload to create a token
-        const payload = {
-            user: {
-                id: user._id,
-                email: user.email,
-                firstname: user.firstname,
-                lastname: user.lastname,
-                username: user.username,
-            },
-        };
-
-        // create a token
-        const token = jwt.sign(payload, secretkey, {
-            expiresIn: 60 * 10 * 1000, // in ms
-        });
-
-        // set the cookie with token with the same age as that of token
-        res.cookie('token', token, {
-            maxAge: 60 * 10 * 1000, // in ms
-            secure: false, // set to true if your using https
-            httpOnly: true,
-            sameSite: 'lax',
-        });
+        createJWTCookie(user, res);
 
         if (typeof serviceURL !== 'undefined' && serviceURL) {
             // render homepage to store token and then redirect with serviceURL

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,0 +1,61 @@
+import jwt, { verify } from 'jsonwebtoken';
+import { secretkey, expTime, rememberTime } from '../config/keys';
+
+const createJWTCookie = (user, res, tokenName = 'token') => {
+    const payload = {
+        user: {
+            id: user._id,
+            email: user.email,
+            firstname: user.firstname,
+            lastname: user.lastname,
+            username: user.username,
+            role: user.role,
+        },
+    };
+    const exp = tokenName === 'rememberme' ? rememberTime : expTime;
+    // create a token
+    const token = jwt.sign(payload, secretkey, {
+        expiresIn: exp, // in ms
+        issuer: 'auth.devclub.in',
+    });
+
+    // set the cookie with token with the same age as that of token
+    res.cookie(tokenName, token, {
+        maxAge: exp, // in ms
+        secure: false, // set to true if your using https
+        httpOnly: true,
+        sameSite: 'lax',
+    });
+};
+
+const verifyToken = (token, res, tokenName = 'token') => {
+    try {
+        const decoded = verify(token, secretkey);
+        const { user } = decoded;
+
+        // Set a new cookie which will extend the session a further {expTime} amount of time.
+        // So essentially whenever any auth request is made the user session will be extended.
+        if (tokenName === 'rememberme') {
+            // Refresh the remember me cookie
+            createJWTCookie(user, res, tokenName);
+        }
+
+        // Refresh the token cookie
+        createJWTCookie(user, res);
+
+        return res.status(200).json({
+            user,
+        });
+    } catch (err) {
+        // I wasn't able to verify the token as it was invalid
+        // clear the token
+        res.clearCookie(tokenName);
+
+        // now send a response
+        return res.status(401).json({
+            err: true,
+            msg: 'Error, token not valid',
+        });
+    }
+};
+export { createJWTCookie, verifyToken };

--- a/src/views/login.ejs
+++ b/src/views/login.ejs
@@ -41,7 +41,8 @@
             <form action="" method="POST">
                 <input type="email" name="email" placeholder="Enter your email ..." required />
                 <input type="password" name="password" placeholder="Enter your password ..." required />
-
+                <input type="checkbox" style="height:20px;width:20px" id="rememberme" name="rememberme" value="true"/>
+                <label for="rememberme">Remember Me!</label>
                 <% if (typeof serviceURL !== undefined && serviceURL) { %>
                 <div class="hiddenElement" id="serviceURL"><%= serviceURL %></div>
                 <input type="text" name="serviceURL" id="serviceURLInput" style="display: none;" />


### PR DESCRIPTION
## Features Added
- Each time a request is made to the auth endpoint for verification of the token, if the token is valid the server renews the expiry time of the token by sending in a new token through the set-cookie header. So session is continuously extended unless there is no activity for 20 min. 
- Remember Me token is implemented which allows a user to be remembered for 2 days and if access token has expired then the remember-me token can be used to get an access token, which will authorize the user.
- However on logout both the remember-me token and access token are deleted.
- Code repetition was eliminated, by making use of exportable functions in auth.js
- Eliminate hard-coding of expiry times by including a config variable in keys.js