### PR TITLE
Deletion endpoint for clients, usage of NODE_ENV realised, introduced superadmins, some bug fixes and code optimisation

### DIFF
--- a/src/config/keys.js
+++ b/src/config/keys.js
@@ -23,4 +23,5 @@ export const r2p = {
     dc_member: 2,
     dc_core: 3,
     admin: 4,
+    superadmin: 5,
 };

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -24,7 +24,10 @@ const HttpsProxyAgent = require('https-proxy-agent');
 
 const axiosDefaultConfig = {
     proxy: false,
-    httpsAgent: new HttpsProxyAgent('http://devclub.iitd.ac.in:3128'),
+    httpsAgent:
+        process.env.NODE_ENV !== 'DEV'
+            ? new HttpsProxyAgent('http://devclub.iitd.ac.in:3128')
+            : null,
 };
 const axios = require('axios').create(axiosDefaultConfig);
 const qs = require('qs');
@@ -34,6 +37,7 @@ router.post('/refresh-token', async (req, res) => {
     const refreshToken = req.body[refreshTokenName];
     try {
         const user = await verifyToken(req, res, true, 0, token, refreshToken);
+        user.password = undefined;
         return res.status(200).json({
             user,
         });
@@ -57,8 +61,12 @@ router.get('/email/verify/token', async (req, res) => {
         res.render('account_verified');
     } catch (error) {
         console.log(error);
-        res.clearCookie(accessTokenName);
-        res.clearCookie(refreshTokenName);
+        res.clearCookie(accessTokenName, {
+            domain: process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
+        });
+        res.clearCookie(refreshTokenName, {
+            domain: process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
+        });
         res.render('account_verified', { error: true });
     }
 });
@@ -114,8 +122,12 @@ router.get('/password/reset/token', async (req, res) => {
         });
     } catch (error) {
         console.log(error);
-        res.clearCookie(accessTokenName);
-        res.clearCookie(refreshTokenName);
+        res.clearCookie(accessTokenName, {
+            domain: process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
+        });
+        res.clearCookie(refreshTokenName, {
+            domain: process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
+        });
         res.render('login', {
             message: 'Invalid Token. Please try resetting your password again',
             error: true,
@@ -329,8 +341,8 @@ router.get('/clientVerify', async (req, res) => {
         const token = createJWTCookie(user, res);
         res.cookie('_token', token, {
             httpOnly: false,
-            domain: 'devclub.in',
-            secure: true,
+            domain: process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
+            secure: process.env.NODE_ENV !== 'DEV',
         });
         return res.status(200).json({
             err: false,

--- a/src/routes/profile.js
+++ b/src/routes/profile.js
@@ -1,9 +1,10 @@
+/* eslint-disable no-await-in-loop */
 /* eslint-disable import/named */
 import express from 'express';
 import { verifyToken, getUserPrivilege } from '../utils/utils';
 import { accessTokenName, refreshTokenName } from '../config/keys';
 import settingsRoutes from './settings';
-import { SocialAccount } from '../models/user';
+import { Client, SocialAccount, User } from '../models/user';
 
 const router = express.Router();
 
@@ -27,10 +28,10 @@ router.post('/', async (req, res) => {
 router.post('/logout', (req, res) => {
     try {
         res.clearCookie(accessTokenName, {
-            domain: 'devclub.in',
+            domain: process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
         });
         res.clearCookie(refreshTokenName, {
-            domain: 'devclub.in',
+            domain: process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
         });
         return res.json({
             err: false,
@@ -47,6 +48,32 @@ router.post('/logout', (req, res) => {
 router.post('/delete', async (req, res) => {
     try {
         const user = await verifyToken(req, res, false);
+
+        const clients = await Client.find({
+            owner: user,
+        });
+        if (clients.length !== 0) {
+            const allUsers = await User.find({});
+            const superAdmins = [];
+            allUsers.forEach((u) => {
+                if (u.roles.includes('superadmin')) superAdmins.push(u);
+            });
+
+            if (superAdmins.length === 0) {
+                return res.status(500).json({
+                    err: true,
+                    msg:
+                        'There is presently no superadmin to which the ownership of your clients can be transferred. Hence account deletion aborted',
+                });
+            }
+            const superAdmin = superAdmins[0];
+            for (let i = 0; i < clients.length; i += 1) {
+                const client = clients[i];
+                client.owner = superAdmin;
+                await client.save();
+            }
+        }
+
         const socialConnections = SocialAccount.find({ primary_account: user });
         (await socialConnections).forEach((social) => {
             social.remove();
@@ -54,7 +81,7 @@ router.post('/delete', async (req, res) => {
         await user.remove();
 
         res.clearCookie(accessTokenName, {
-            domain: 'devclub.in',
+            domain: process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
         });
         return res.status(200).json({
             err: false,

--- a/src/routes/settings.js
+++ b/src/routes/settings.js
@@ -100,7 +100,10 @@ router.post('/', async (req, res) => {
                 res.render('settings', { messages });
             } else {
                 // If the validation was successful, update the user and create a new JWT for the updated credentials
-                res.clearCookie(accessTokenName);
+                res.clearCookie(accessTokenName, {
+                    domain:
+                        process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
+                });
                 await createJWTCookie(user, res);
                 res.render('settings', { messages });
             }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -11,7 +11,10 @@ const HttpsProxyAgent = require('https-proxy-agent');
 
 const axiosDefaultConfig = {
     proxy: false,
-    httpsAgent: new HttpsProxyAgent('http://devclub.iitd.ac.in:3128'),
+    httpsAgent:
+        process.env.NODE_ENV !== 'DEV'
+            ? new HttpsProxyAgent('http://devclub.iitd.ac.in:3128')
+            : null,
 };
 const axios = require('axios').create(axiosDefaultConfig);
 
@@ -59,10 +62,10 @@ const createJWTCookie = (user, res, tokenName = keys.accessTokenName) => {
     // set the cookie with token with the same age as that of token
     res.cookie(tokenName, token, {
         maxAge: exp * 1000, // in milli seconds
-        secure: true, // set to true if you are using https
+        secure: process.env.NODE_ENV !== 'DEV', // set to true if you are using https
         httpOnly: true,
         sameSite: 'lax',
-        domain: 'devclub.in',
+        domain: process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
     });
     return token;
 };
@@ -112,10 +115,10 @@ const verifyToken = async (
         // I wasn't able to verify the token as it was invalid
         // clear the tokens
         res.clearCookie(keys.accessTokenName, {
-            domain: 'devclub.in',
+            domain: process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
         });
         res.clearCookie(keys.refreshTokenName, {
-            domain: 'devclub.in',
+            domain: process.env.NODE_ENV !== 'DEV' ? 'devclub.in' : null,
         });
         throw err;
     }


### PR DESCRIPTION
Some feature additions and bug fixes
1. Now use `NODE_ENV` to easily change the behaviour of cookies which will allow easier local debugging
2. Introduced the concept of superadmins
3. Made deletion endpoint for client which also deletes all the roles associated with the client from user roles 
4. Modified user deletion endpoint to check if the user has a client and then transfer their ownership to the superadmin. Closes #86 
5. A bug fix that led to reveal of hashed passwords in `refresh-token` method.
6. Made the code a bit modular in `client.js`